### PR TITLE
Enable backtracking from background job to recurrent job

### DIFF
--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -127,7 +127,10 @@ namespace Hangfire
                     state.Queue = hash["Queue"];
                 }
 
-                _factory.Create(new CreateContext(_storage, connection, job, state));
+                var context = new CreateContext(_storage, connection, job, state);
+                context.Items["RecurringJobId"] = recurringJobId;
+                context.Parameters["RecurringJobId"] = recurringJobId;
+                _factory.Create(context);
             }
         }
 

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -186,7 +186,10 @@ namespace Hangfire.Server
                         state.Queue = recurringJob["Queue"];
                     }
 
-                    var backgroundJob = _factory.Create(new CreateContext(storage, connection, job, state));
+                    var context = new CreateContext(storage, connection, job, state);
+                    context.Items["RecurringJobId"] = recurringJobId;
+                    context.Parameters["RecurringJobId"] = recurringJobId;
+                    var backgroundJob = _factory.Create(context);
                     var jobId = backgroundJob != null ? backgroundJob.Id : null;
 
                     if (String.IsNullOrEmpty(jobId))


### PR DESCRIPTION
Enable the Background Job context to hold the Recurrent Job ID that
spawned it.
